### PR TITLE
update requirement file after successfully installed sphinx-rtd-theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,6 +12,7 @@ gitdb==4.0.9
 GitPython==3.1.27
 idna==2.10
 imagesize==1.3.0
+importlib-metadata==4.12.0
 Jinja2==3.1.2
 jsonschema==4.15.0
 livereload==2.6.3
@@ -30,13 +31,14 @@ six==1.16.0
 smmap==5.0.0
 snowballstemmer==2.2.0
 soupsieve==2.3.2.post1
-Sphinx==4.3.2
+Sphinx==4.5.0
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.4.0
 sphinx-external-toc==0.2.3
 sphinx-gitstamp==0.3.2
 sphinx-notfound-page==0.8
 sphinx-panels==0.6.0
+sphinx-rtd-theme==1.0.0
 sphinx-sitemap==2.2.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
@@ -49,3 +51,4 @@ sphinxext-opengraph==0.4.2
 toml==0.10.2
 tornado==6.1
 urllib3==1.26.9
+zipp==3.8.1


### PR DESCRIPTION
Having issue with the theme sphinx_rtd_theme.
<img width="909" alt="Screenshot 2022-09-06 at 14 09 12" src="https://user-images.githubusercontent.com/3796599/188648247-f3129b31-643f-4e7b-98ff-d1f005668d89.png">

Tried renaming sphinx-rtd-theme with dashes instead of underscores but didn't help. 
End up using [this method](https://github.com/readthedocs/sphinx_rtd_theme/issues/618#issuecomment-455998297) and it works.

As a result the requirements.txt needs to be updated.

```
pip uninstall sphinx sphinx_rtd_theme
pip install sphinx sphinx_rtd_theme
```