### PR TITLE
fixes: Update doc term klaw correctly

### DIFF
--- a/.github/vale/styles/Klaw/branding-warning-temp.yml
+++ b/.github/vale/styles/Klaw/branding-warning-temp.yml
@@ -10,6 +10,4 @@ swap:
   "(?i)Confluent Cloud": Confluent Cloud
   "(?i)api": API
   "(?i)kafka connect": Kafka Connect
-  "(?i)klaw core": Klaw Core
-  "(?i)klaw": Klaw
-  
+  "(?i)klaw core": Klaw Core  

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -22,3 +22,4 @@ swap:
   "node[ -]?js?": NodeJS
   "type[ -]?scripts?": TypeScript
   "(?i)ssl": SSL
+  "(?i)klaw": Klaw

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.md
@@ -48,7 +48,7 @@ Kafka® and Klaw using SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [Klaw/cluster-api/src/main/resources] directory.
+   `klaw/cluster-api/src/main/resources` directory.
 10. Depending on your SASL mechanism, copy one of the below properties, replace `clusterid` with the copied cluster id,
     and save the `application.properties` file.
 

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.md
@@ -48,7 +48,7 @@ Kafka® and Klaw using SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [klaw/cluster-api/src/main/resources] directory.
+   [Klaw/cluster-api/src/main/resources] directory.
 10. Depending on your SASL mechanism, copy one of the below properties, replace `clusterid` with the copied cluster id,
     and save the `application.properties` file.
 


### PR DESCRIPTION
This PR will fixes #104 which is Update docs to use the term "Klaw" correctly.

Fixes #104 

After updating code and run ```npm run spell:error``` Here is the result:)
 
![image](https://github.com/Aiven-Open/klaw-docs/assets/97227305/a83d9a58-7cfe-4722-b990-672439d3d28f)


This will fallow code of conduct as of my knowledge.
For further queries feel free to connect.

Hope this will merge as soon as possible.

Happy coding🤝.