### PR TITLE
(ci) Update vale workflow reporter

### DIFF
--- a/.github/vale/styles/Klaw/branding-warning-temp.yml
+++ b/.github/vale/styles/Klaw/branding-warning-temp.yml
@@ -10,4 +10,5 @@ swap:
   "(?i)Confluent Cloud": Confluent Cloud
   "(?i)api": API
   "(?i)kafka connect": Kafka Connect
-  "(?i)klaw core": Klaw Core  
+  "(?i)klaw core": Klaw Core
+  "(?i)klaw": Klaw

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -22,4 +22,3 @@ swap:
   "node[ -]?js?": NodeJS
   "type[ -]?scripts?": TypeScript
   "(?i)ssl": SSL
-  "(?i)klaw": Klaw

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -19,11 +19,16 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Run vale
-        uses: errata-ai/vale-action@c4213d4de3d5f718b8497bd86161531c78992084 #v2.0.1
-        with:
-          fail_on_error: true
-          vale_flags: "--glob='!.github/vale/styles/*' --minAlertLevel=error"
-          reporter: github-pr-check
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        # While Vale offers an action, based on review dog, but that didn't work
+        # to catch errors that are not in files outside of the diff of the PR
+        # We need to run the pipeline for all files at least as long as we introduce
+        # new styles frequently. This is why I followed this approach for running Vale.working-directory:
+        # https://github.com/reviewdog/reviewdog/issues/1408
+      - name: Install Vale
+        run: |
+          wget https://github.com/errata-ai/vale/releases/download/v2.29.1/vale_2.29.1_Linux_64-bit.tar.gz -O vale.tar.gz
+          tar -xvzf vale.tar.gz vale
+          rm vale.tar.gz
+
+      - name: Run Vale
+        run: ./vale --glob='!.github/vale/styles/*' . --minAlertLevel=error --config=.vale.ini

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -2,7 +2,7 @@
 
 We adhere to the [Google developer documentation style guide](https://developers.google.com/style). We're also establishing a more detailed custom guidelines, which is documented here.
 
-You can run a Vale check for all available styles by running `npm run spell:all`. At the moment, only the level `error` is a established styleguide for us. Checking for warnings or suggestions is meant to be used as inspiration and support.
+You can run a Vale check for all available styles by running `npm run spell:all`. At the moment, only the level `error` is a established style guide for us. Checking for warnings or suggestions is meant to be used as inspiration and support.
 
 Where possible, these rules are checked automatically using Vale. For more information on how this is set up, see
 our [Vale documentation](.github/vale/vale.md).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "reformat": "npm run reformat:code && npm run reformat:markdown",
     "lint-staged": "lint-staged",
     "markdown-link-check": "markdown-link-check-script/markdown-link-check.sh",
-    "spell:error": "vale --glob='!.github/vale/styles/*' . --minAlertLevel=error ",
+    "spell:error": "vale --glob='!.github/vale/styles/*' . --minAlertLevel=error",
     "spell:warn": "vale --glob='!.github/vale/styles/*' . --minAlertLevel=warning",
     "spell:all": "vale --glob='!.github/vale/styles/*' . --minAlertLevel=suggestion"
   },


### PR DESCRIPTION
# Description

I noticed that our vale action is not running as expected. 

It does not raise errors even so it logs them. 

This seems to be related to reviewdog, which is used by the vale action. While I got it to work fine (I think, based on my testing) with checking the files that are in the diff, I didn't get it to fail on errors in other files, even so the errors are clearly there and even logged. 

After a bit of research I found this issue: https://github.com/reviewdog/reviewdog/issues/1408 
and based my fix on that. I've confirmed that this works as expected, at least on this PR for now. 

## This PR
- changes the vale workflow to cover all markdown files correctly
- fixes a spelling issue that did went under the radar of the action before
- removes a branding rule for "Klaw" as error and adds it in the temp list again. I'll open an issue to fix this (again). There as already a PR that fixed that (we thought), but the pipeline was only green because of this unexpected behaviour. 

