### PR TITLE
 Update correct usage of copyright for PostgreSQL #109 

### DIFF
--- a/.github/vale/styles/Klaw/first-postgresql-registered.yml
+++ b/.github/vale/styles/Klaw/first-postgresql-registered.yml
@@ -1,6 +1,6 @@
 extends: conditional
 message: "The first mention of '%s' must be marked as ®"
-level: warning
+level: error
 scope: text
 ignorecase: false
 

--- a/blog/2023/07/high-availability-for-klaw.md
+++ b/blog/2023/07/high-availability-for-klaw.md
@@ -216,7 +216,7 @@ Core Governance Application / Cluster Application
 ### Database management system
 
 For the RDBMS, Klaw is compatible with various database management
-systems such as PostgreSQL, MySQL, and others.
+systems such as PostgreSQL®, MySQL, and others.
 
 Note: While the above configurations have been tested and proven to work
 effectively, there are no guarantees that they will suit every use case.

--- a/docs/HowTo/clusterconnectivity/klaw-db-connection.md
+++ b/docs/HowTo/clusterconnectivity/klaw-db-connection.md
@@ -4,7 +4,7 @@ Klaw uses a database to store metadata, such as information about users,
 teams, and owners. This allows the system to track and manage access to
 resources within an organization/team. By default, Klaw uses a
 file-based database. However, you can also configure Klaw to use various
-RDBMS, such as MySQL, Oracle, or PostgreSQL.
+RDBMS, such as MySQL, Oracle, or PostgreSQL®.
 
 The configuration for the default file-based database in Klaw is
 specified in the `application.properties` file in the core


### PR DESCRIPTION
##Description

- Fixes the usage of trademark in PostgreSQL.

##Test
`npm run spell:error` was green, no spelling errors found.

{Update correct usage of copyright for PostgreSQL}#109 