### PR TITLE
update-doc-Klaw-Core

### DIFF
--- a/.github/vale/styles/Klaw/branding-warning-temp.yml
+++ b/.github/vale/styles/Klaw/branding-warning-temp.yml
@@ -10,4 +10,4 @@ swap:
   "(?i)Confluent Cloud": Confluent Cloud
   "(?i)api": API
   "(?i)kafka connect": Kafka Connect
-  "(?i)klaw core": Klaw Core  
+  

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -23,3 +23,4 @@ swap:
   "type[ -]?scripts?": TypeScript
   "(?i)ssl": SSL
   "(?i)klaw": Klaw
+  "(?i)klaw core": Klaw Core  

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1.0
 
 Klaw consists of two components:
 
-- The main Klaw core application handling Governance, Security and meta storage.
+- The main Klaw Core application handling Governance, Security and meta storage.
 - The Cluster API handling the connections to the Apache Kafka,
   Apache Kafka Connect and Schema Registry servers.
 


### PR DESCRIPTION
This PR will fixes #103  update docs to use the term "Klaw Core" correctly

fixes #103 

![Screenshot 2023-09-28 224329](https://github.com/Aiven-Open/klaw-docs/assets/104249536/40ef1603-dcfd-47bb-a4c6-c3079f0ab9b6)

For further queries feel free to connect.

Hope this will merge as soon as possible.