### PR TITLE
Updated branding.yml and respective files to help docs to use the term "Confluent Cloud" correctly.

### DIFF
--- a/.github/vale/styles/Klaw/branding-warning-temp.yml
+++ b/.github/vale/styles/Klaw/branding-warning-temp.yml
@@ -7,7 +7,6 @@ ignorecase: true
 swap:
   "(?<!Apache )kafka": Apache Kafka
   "(?<!Klaw )cluster api": Klaw Cluster API
-  "(?i)Confluent Cloud": Confluent Cloud
   "(?i)api": API
   "(?i)kafka connect": Kafka Connect
   "(?i)klaw core": Klaw Core

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -6,6 +6,7 @@ ignorecase: true
 # Vale will ignore any alerts that match the intended form.
 swap:
   "(?i)Confluent": Confluent
+  "(?i)Confluent[ -]?Cloud": Confluent Cloud
   "(?i)acl": ACL
   "(?i)apache": Apache
   "(?i)google": Google

--- a/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
@@ -43,7 +43,7 @@ Follow the steps below to configure and connect to a Confluent Cloud Kafka and K
    - **Cluster Name:** Provide a name for the cluster
    - **Protocol:** Select SSL protocol for your cluster
    - **Kafka Flavor:** Select Confluent Cloud Kafka as the flavor
-   - **Bootstrap server:** Enter the REST endpoint of your Confluent cloud Kafka cluster (without <https://>). Ex:
+   - **Bootstrap server:** Enter the REST endpoint of your Confluent Cloud Kafka cluster (without <https://>). Ex:
      `xyz-pk07es.us-west4.gcp.confluent.cloud:443`
 
 4. Click **Save**.


### PR DESCRIPTION
Description
   I have made the changes in branding.yml and branding-warning-temp.yml files to help docs use the term "Confluent Cloud" correctly.

Notes for Reviewers
Test:   npm run spell: error was green, no spelling errors found.
 npm run spell:error                             
> klaw-docs@1.0.0 spell:error
> vale --glob='!.github/vale/styles/*' . --minAlertLevel=error
✔ 0 errors, 0 warnings and 0 suggestions in 0 files.

Please check the above changes if I did anything wrong please let me know.

This PR fixes #100 
    
