### PR TITLE
use term "API" correctly

### DIFF
--- a/.github/vale/styles/Klaw/branding-warning-temp.yml
+++ b/.github/vale/styles/Klaw/branding-warning-temp.yml
@@ -6,6 +6,5 @@ ignorecase: true
 # Vale will ignore any alerts that match the intended form.
 swap:
   "(?<!Apache )kafka": Apache Kafka
-  "(?i)api": API
   "(?i)klaw core": Klaw Core
   "(?i)klaw": Klaw

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -25,3 +25,4 @@ swap:
   "(?i)ssl": SSL
   "(?<!Klaw )cluster api": Klaw Cluster API
   "(?i)kafka[ -]?connect": Kafka Connect
+  "(?i)api": API

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -25,4 +25,3 @@ swap:
   "(?i)ssl": SSL
   "(?<!Klaw )cluster api": Klaw Cluster API
   "(?i)kafka[ -]?connect": Kafka Connect
-  "(?i)api": API

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.md
@@ -50,7 +50,7 @@ Kafka® and Klaw using SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [klaw/cluster-API/src/main/resources] directory.
+   `klaw/cluster-api/src/main/resources` directory.
 10. Configure the SSL properties to connect to Aiven for Apache Kafka®
     clusters by copying and editing the following lines.
 

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.md
@@ -50,7 +50,7 @@ Kafka® and Klaw using SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [klaw/cluster-api/src/main/resources] directory.
+   [klaw/cluster-API/src/main/resources] directory.
 10. Configure the SSL properties to connect to Aiven for Apache Kafka®
     clusters by copying and editing the following lines.
 

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
@@ -52,7 +52,7 @@ Kafka Connect service with Klaw using SSL protocol:
    the copy icon that is available on the right-hand side of each
    cluster row.
 
-8. In the `application.properties` file for [cluster-API] (klaw/cluster-api/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console:
+8. In the `application.properties` file for [`cluster-api`](klaw/cluster-api/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console:
 
    `clusterid.klaw.kafkaconnect.credentials=username:password`
 

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
@@ -52,7 +52,7 @@ Kafka Connect service with Klaw using SSL protocol:
    the copy icon that is available on the right-hand side of each
    cluster row.
 
-8. In the `application.properties` file for [cluster-api] (klaw/cluster-api/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console:
+8. In the `application.properties` file for [cluster-API] (klaw/cluster-API/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console:
 
    `clusterid.klaw.kafkaconnect.credentials=username:password`
 

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
@@ -52,7 +52,7 @@ Kafka Connect service with Klaw using SSL protocol:
    the copy icon that is available on the right-hand side of each
    cluster row.
 
-8. In the `application.properties` file for [cluster-API] (klaw/cluster-API/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console:
+8. In the `application.properties` file for [cluster-API] (klaw/cluster-api/src/main/resources) module, configure Aiven for Apache Kafka Connect credentials copied from Aiven console:
 
    `clusterid.klaw.kafkaconnect.credentials=username:password`
 

--- a/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
@@ -44,14 +44,14 @@ registry cluster with Klaw using SSL protocol:
 6. In the **Schema Registry Environments** section, click **Add
    Environment** and enter the details to add your schema registry
    environment. Click **Save**.
-7. Open the `application.properties` file for [cluster-API]
-   (klaw/cluster-API/src/main/resources) modules.
+7. Open the `application.properties` file for [`cluster-api`]
+   (klaw/cluster-api/src/main/resources) modules.
 8. Copy the **Cluster ID** from the **Clusters** page using the copy
    icon that is available on the right-hand side of each cluster
    row.
 
 9. In the `application.properties` file
-   for [cluster-API](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources/application.properties)
+   for [`cluster-api`](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources/application.properties)
    module, configure Karapace credentials copied from the Aiven console
 
    `clusterid.klaw.schemaregistry.credentials=username:password`

--- a/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
@@ -44,8 +44,7 @@ registry cluster with Klaw using SSL protocol:
 6. In the **Schema Registry Environments** section, click **Add
    Environment** and enter the details to add your schema registry
    environment. Click **Save**.
-7. Open the `application.properties` file for [`cluster-api`]
-   (klaw/cluster-api/src/main/resources) modules.
+7. Open the `application.properties` file for [`cluster-api`](klaw/cluster-api/src/main/resources) modules.
 8. Copy the **Cluster ID** from the **Clusters** page using the copy
    icon that is available on the right-hand side of each cluster
    row.

--- a/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
@@ -44,14 +44,14 @@ registry cluster with Klaw using SSL protocol:
 6. In the **Schema Registry Environments** section, click **Add
    Environment** and enter the details to add your schema registry
    environment. Click **Save**.
-7. Open the `application.properties` file for [cluster-api]
-   (klaw/cluster-api/src/main/resources) modules.
+7. Open the `application.properties` file for [cluster-API]
+   (klaw/cluster-API/src/main/resources) modules.
 8. Copy the **Cluster ID** from the **Clusters** page using the copy
    icon that is available on the right-hand side of each cluster
    row.
 
 9. In the `application.properties` file
-   for [cluster-api](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources/application.properties)
+   for [cluster-API](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources/application.properties)
    module, configure Karapace credentials copied from the Aiven console
 
    `clusterid.klaw.schemaregistry.credentials=username:password`

--- a/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
@@ -57,7 +57,7 @@ Follow the steps below to configure and connect to a Confluent Cloud Kafka and K
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [klaw/cluster-api/src/main/resources] directory.
+   [klaw/cluster-API/src/main/resources] directory.
 10. Configure the API key, API secret, URIs to connect to Confluent Cloud
     Kafka clusters by copying and editing the following lines:
 

--- a/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
@@ -57,7 +57,7 @@ Follow the steps below to configure and connect to a Confluent Cloud Kafka and K
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [klaw/cluster-API/src/main/resources] directory.
+   `klaw/cluster-api/src/main/resources` directory.
 10. Configure the API key, API secret, URIs to connect to Confluent Cloud
     Kafka clusters by copying and editing the following lines:
 

--- a/docs/HowTo/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.md
@@ -37,7 +37,7 @@ cluster in Klaw using SASL_SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [cluster-API](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources) directory.
+   [`cluster-api`](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources) directory.
 10. Depending on your SASL mechanism, copy one of the below
     properties, replace `clusterid` with the copied cluster id, and save
     the `application.properties` file.

--- a/docs/HowTo/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.md
@@ -37,7 +37,7 @@ cluster in Klaw using SASL_SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [cluster-api](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources) directory.
+   [cluster-API](https://github.com/aiven/klaw/blob/main/cluster-api/src/main/resources) directory.
 10. Depending on your SASL mechanism, copy one of the below
     properties, replace `clusterid` with the copied cluster id, and save
     the `application.properties` file.

--- a/docs/HowTo/clusterconnectivity/kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/kafka-cluster-ssl-protocol.md
@@ -43,7 +43,7 @@ cluster in Klaw using SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [klaw/cluster-api/src/main/resources] directory.
+   [klaw/cluster-API/src/main/resources] directory.
 
 10. Configure the SSL properties to connect to Apache Kafka clusters by copying and editing the following lines:
 

--- a/docs/HowTo/clusterconnectivity/kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/kafka-cluster-ssl-protocol.md
@@ -43,7 +43,7 @@ cluster in Klaw using SSL protocol:
    icon that is available on the right-hand side of each cluster
    row.
 9. Open the `application.properties` file located in the
-   [klaw/cluster-API/src/main/resources] directory.
+   `klaw/cluster-api/src/main/resources` directory.
 
 10. Configure the SSL properties to connect to Apache Kafka clusters by copying and editing the following lines:
 

--- a/docs/HowTo/clusterconnectivity/klaw-core-with-clusterapi.md
+++ b/docs/HowTo/clusterconnectivity/klaw-core-with-clusterapi.md
@@ -7,7 +7,7 @@ respective `application.properties` files and verifying the connectivity between
 You can find the `application.properties` file located in the following paths:
 
 - Core: [klaw/core/src/main/resources]
-- Cluster-api: [klaw/cluster-api/src/main/resources]
+- Cluster-API: [klaw/cluster-API/src/main/resources]
 
 ## Configure Klaw application.properties file
 

--- a/docs/HowTo/clusterconnectivity/klaw-core-with-clusterapi.md
+++ b/docs/HowTo/clusterconnectivity/klaw-core-with-clusterapi.md
@@ -7,7 +7,7 @@ respective `application.properties` files and verifying the connectivity between
 You can find the `application.properties` file located in the following paths:
 
 - Core: [klaw/core/src/main/resources]
-- Cluster-API: [klaw/cluster-API/src/main/resources]
+- Cluster-API: `klaw/cluster-api/src/main/resources`
 
 ## Configure Klaw application.properties file
 

--- a/docs/HowTo/clusterconnectivity/sr-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/sr-cluster-ssl-protocol.md
@@ -39,7 +39,7 @@ cluster with Klaw using SSL protocol:
     Environment** and enter the details to add your schema registry
     environment. Click **Save**.
 7.  Open the `application.properties` file for [core](https://github.com/aiven/klaw/tree/main/core)
-    and [cluster-api](https://github.com/aiven/klaw/tree/main/cluster-api) modules.
+    and [cluster-API](https://github.com/aiven/klaw/tree/main/cluster-api) modules.
 
 8.  Copy the **Cluster ID** from the **Clusters** page using the copy
     icon that is available on the right-hand side of each cluster

--- a/docs/HowTo/clusterconnectivity/sr-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/sr-cluster-ssl-protocol.md
@@ -39,7 +39,7 @@ cluster with Klaw using SSL protocol:
     Environment** and enter the details to add your schema registry
     environment. Click **Save**.
 7.  Open the `application.properties` file for [core](https://github.com/aiven/klaw/tree/main/core)
-    and [cluster-API](https://github.com/aiven/klaw/tree/main/cluster-api) modules.
+    and [`cluster-api`](https://github.com/aiven/klaw/tree/main/cluster-api) modules.
 
 8.  Copy the **Cluster ID** from the **Clusters** page using the copy
     icon that is available on the right-hand side of each cluster

--- a/docs/HowTo/installation/run-source.md
+++ b/docs/HowTo/installation/run-source.md
@@ -28,7 +28,7 @@ the source.
    - Configure the property `klaw.clusterapi.access.base64.secret` in the `application.properties` file with a base64
      string in the module: core.
    - Configure the property `klaw.clusterapi.access.base64.secret` in the `application.properties` file with the above
-     base64 string in the module: cluster-API.
+     base64 string in the module: `cluster-api`.
 
    ```{.bash caption="Bash Generation Example"}
    echo "ThisIsExactlyA32CharStringSecret" | base64
@@ -42,7 +42,7 @@ the source.
 
 4. Build the project by running `./mvnw clean package` for Linux(bash) or `mvnw clean package` for Windows, from the top
    level of the project directory. This will build JAR files in the `target/` directories of each module: core and
-   cluster-API.
+   `cluster-api`.
 
    node, npm, and pnpm are also installed locally (required for React UI assets) through maven execution plugins.
 

--- a/docs/HowTo/installation/run-source.md
+++ b/docs/HowTo/installation/run-source.md
@@ -28,7 +28,7 @@ the source.
    - Configure the property `klaw.clusterapi.access.base64.secret` in the `application.properties` file with a base64
      string in the module: core.
    - Configure the property `klaw.clusterapi.access.base64.secret` in the `application.properties` file with the above
-     base64 string in the module: cluster-api.
+     base64 string in the module: cluster-API.
 
    ```{.bash caption="Bash Generation Example"}
    echo "ThisIsExactlyA32CharStringSecret" | base64
@@ -42,7 +42,7 @@ the source.
 
 4. Build the project by running `./mvnw clean package` for Linux(bash) or `mvnw clean package` for Windows, from the top
    level of the project directory. This will build JAR files in the `target/` directories of each module: core and
-   cluster-api.
+   cluster-API.
 
    node, npm, and pnpm are also installed locally (required for React UI assets) through maven execution plugins.
 

--- a/docs/Releases/release110.md
+++ b/docs/Releases/release110.md
@@ -18,7 +18,7 @@ improvements.
   connect to Apache Kafka clusters.
 - Enabled JWT-based authentication: Enabled JWT-based authentication
   to connect to Klaw Cluster API. You can configure
-  klaw.clusterapi.access.base64.secret in both core and cluster-API
+  klaw.clusterapi.access.base64.secret in both core and Cluster API
   modules to enable this authentication between APIs.
 - Connect to multiple clusters using SSL: This release includes the
   functionality to configure Klaw to connect to multiple Apache Kafka

--- a/docs/Releases/release110.md
+++ b/docs/Releases/release110.md
@@ -18,7 +18,7 @@ improvements.
   connect to Apache Kafka clusters.
 - Enabled JWT-based authentication: Enabled JWT-based authentication
   to connect to Klaw Cluster API. You can configure
-  klaw.clusterapi.access.base64.secret in both core and Cluster API
+  klaw.clusterapi.access.base64.secret in both core and Klaw Cluster API
   modules to enable this authentication between APIs.
 - Connect to multiple clusters using SSL: This release includes the
   functionality to configure Klaw to connect to multiple Apache Kafka

--- a/docs/Releases/release110.md
+++ b/docs/Releases/release110.md
@@ -18,7 +18,7 @@ improvements.
   connect to Apache Kafka clusters.
 - Enabled JWT-based authentication: Enabled JWT-based authentication
   to connect to Klaw Cluster API. You can configure
-  klaw.clusterapi.access.base64.secret in both core and cluster-api
+  klaw.clusterapi.access.base64.secret in both core and cluster-API
   modules to enable this authentication between APIs.
 - Connect to multiple clusters using SSL: This release includes the
   functionality to configure Klaw to connect to multiple Apache Kafka

--- a/docs/Releases/release240.md
+++ b/docs/Releases/release240.md
@@ -18,7 +18,7 @@ schemas from schema registry to Klaw, and vice versa.
 
 [klaw-2.4.0.jar ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.4.0/klaw-2.4.0.jar)
 
-[cluster-api-2.4.0.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.4.0/cluster-api-2.4.0.jar)
+[cluster-API-2.4.0.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.4.0/cluster-api-2.4.0.jar)
 
 ### Sources
 

--- a/docs/Releases/release240.md
+++ b/docs/Releases/release240.md
@@ -18,7 +18,7 @@ schemas from schema registry to Klaw, and vice versa.
 
 [klaw-2.4.0.jar ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.4.0/klaw-2.4.0.jar)
 
-[cluster-API-2.4.0.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.4.0/cluster-api-2.4.0.jar)
+[`cluster-api-2.4.0.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.4.0/cluster-api-2.4.0.jar)
 
 ### Sources
 

--- a/docs/Releases/release250.md
+++ b/docs/Releases/release250.md
@@ -18,7 +18,7 @@ schemas from schema registry to Klaw, and vice versa.
 
 [klaw-2.5.0.jar ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.5.0/klaw-2.5.0.jar)
 
-[cluster-api-2.5.0.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.0/cluster-api-2.5.0.jar)
+[cluster-API-2.5.0.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.0/cluster-api-2.5.0.jar)
 
 ### Sources
 
@@ -27,7 +27,7 @@ schemas from schema registry to Klaw, and vice versa.
 ### Docker
 
 [Klaw-core](https://hub.docker.com/r/aivenoy/klaw-core)
-[Klaw-cluster-api](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+[Klaw-cluster-API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
 
 ## What's new in Klaw 2.5.0
 

--- a/docs/Releases/release250.md
+++ b/docs/Releases/release250.md
@@ -18,7 +18,7 @@ schemas from schema registry to Klaw, and vice versa.
 
 [klaw-2.5.0.jar ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.5.0/klaw-2.5.0.jar)
 
-[cluster-API-2.5.0.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.0/cluster-api-2.5.0.jar)
+[`cluster-api-2.5.0.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.0/cluster-api-2.5.0.jar)
 
 ### Sources
 

--- a/docs/Releases/release251.md
+++ b/docs/Releases/release251.md
@@ -16,7 +16,7 @@ Klaw version 2.5.1 is a patch release primarily aimed at enhancing MySQL support
 
 - [klaw-2.5.1.jar ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.5.1/klaw-2.5.1.jar)
 
-- [cluster-API-2.5.1.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.1/cluster-api-2.5.1.jar)
+- [`cluster-api-2.5.1.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.1/cluster-api-2.5.1.jar)
 
 ### Sources
 

--- a/docs/Releases/release251.md
+++ b/docs/Releases/release251.md
@@ -16,7 +16,7 @@ Klaw version 2.5.1 is a patch release primarily aimed at enhancing MySQL support
 
 - [klaw-2.5.1.jar ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.5.1/klaw-2.5.1.jar)
 
-- [cluster-api-2.5.1.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.1/cluster-api-2.5.1.jar)
+- [cluster-API-2.5.1.jar ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.5.1/cluster-api-2.5.1.jar)
 
 ### Sources
 
@@ -25,7 +25,7 @@ Klaw version 2.5.1 is a patch release primarily aimed at enhancing MySQL support
 ### Docker
 
 - [Klaw-core](https://hub.docker.com/r/aivenoy/klaw-core)
-- [Klaw-cluster-api](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+- [Klaw-cluster-API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
 
 ## What's new in Klaw 2.5.1
 


### PR DESCRIPTION
Cut and past the line related to API ("(?i)api") from branding-warning-temp.yml and add it to branding.yaml
Run npm run spell:error and revise all the wrong uses according to the result.

After revising, no errors:
<img width="459" alt="image" src="https://github.com/Aiven-Open/klaw-docs/assets/20795443/99397a7a-664c-4c73-8594-e1f3ff6e5f8b">



Closes #101 