### PR TITLE
Update snowplow config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,6 +26,7 @@ const config = {
   onBrokenMarkdownLinks: "warn",
 
   clientModules: [require.resolve("./snowplow.js")],
+
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".

--- a/snowplow.js
+++ b/snowplow.js
@@ -8,7 +8,7 @@ const trackerConfig = {
   discoverRootDomain: true,
   cookieSameSite: "Lax",
   anonymousTracking: { withServerAnonymisation: true },
-  postPath: "/aiven/dc",
+  postPath: "/aiven/dc2",
   crossDomainLinker: function (linkElement) {
     return linkElement.id === "crossDomainLink";
   },

--- a/snowplow.js
+++ b/snowplow.js
@@ -1,6 +1,7 @@
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 import { newTracker, trackPageView } from "@snowplow/browser-tracker";
 
+const isProduction = process.env.NODE_ENV === "production";
 const trackerConfig = {
   appId: "klaw-docs",
   platform: "web",
@@ -23,17 +24,22 @@ function setupBrowserTracker() {
   newTracker("at", "dc.aiven.io", trackerConfig);
 }
 
-if (ExecutionEnvironment.canUseDOM) {
+if (isProduction && ExecutionEnvironment.canUseDOM) {
+  // only set tracker on prod
   setupBrowserTracker();
 }
 
 const module = {
   onRouteDidUpdate({ location, previousLocation }) {
-    if (location.pathname !== previousLocation?.pathname) {
-      // see https://github.com/facebook/docusaurus/pull/7424 regarding setTimeout
-      setTimeout(() => {
-        trackPageView();
-      });
+    // only set tracker on prod
+    if (isProduction) {
+      // only call trackPageView when page route changed
+      if (location.pathname !== previousLocation?.pathname) {
+        // see https://github.com/facebook/docusaurus/pull/7424 regarding setTimeout
+        setTimeout(() => {
+          trackPageView();
+        });
+      }
     }
   },
 };

--- a/snowplow.js
+++ b/snowplow.js
@@ -25,7 +25,17 @@ function setupBrowserTracker() {
 
 if (ExecutionEnvironment.canUseDOM) {
   setupBrowserTracker();
-  trackPageView();
 }
+
+const module = {
+  onRouteDidUpdate({ location, previousLocation }) {
+    if (location.pathname !== previousLocation?.pathname) {
+      // see https://github.com/facebook/docusaurus/pull/7424 regarding setTimeout
+      setTimeout(() => {
+        trackPageView();
+      });
+    }
+  },
+};
 
 export default module;

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -140,7 +140,7 @@ function Feature({ Svg, title, description }) {
 Feature.propTypes = {
   Svg: PropTypes.any,
   title: PropTypes.string,
-  description: PropTypes.string,
+  description: PropTypes.node,
 };
 
 export default function HomepageFeatures() {


### PR DESCRIPTION
# Description

While Docusarus generates static HTML files, it uses client-site routing for a smoother experience. That's why we have to call the page view tracking on every route change. 

see:
- https://github.com/facebook/docusaurus/issues/3399
- https://github.com/snowplow/documentation/blob/main/snowplow.js


Note
- this PR also fixes a prop-type