### PR TITLE
Update usage of "Klaw Core"

### DIFF
--- a/.github/vale/styles/Klaw/branding-warning-temp.yml
+++ b/.github/vale/styles/Klaw/branding-warning-temp.yml
@@ -6,5 +6,4 @@ ignorecase: true
 # Vale will ignore any alerts that match the intended form.
 swap:
   "(?<!Apache )kafka": Apache Kafka
-  "(?i)klaw core": Klaw Core
   "(?i)klaw": Klaw

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -23,7 +23,7 @@ swap:
   "node[ -]?js?": NodeJS
   "type[ -]?scripts?": TypeScript
   "(?i)ssl": SSL
-  "(?<!Klaw )cluster api": Klaw Cluster API
+  "(?i)klaw[- ]cluster[- ]api": Klaw Cluster API
   "(?i)kafka[ -]?connect": Kafka Connect
   "(?i)zookeeper": ZooKeeper
   "(?i)api": API

--- a/.github/vale/styles/Klaw/branding.yml
+++ b/.github/vale/styles/Klaw/branding.yml
@@ -27,3 +27,4 @@ swap:
   "(?i)kafka[ -]?connect": Kafka Connect
   "(?i)zookeeper": ZooKeeper
   "(?i)api": API
+  "(?i)klaw[- ]core": Klaw Core

--- a/blog/2023/07/high-availability-for-klaw.md
+++ b/blog/2023/07/high-availability-for-klaw.md
@@ -259,7 +259,7 @@ Detailed information can be found on the official Nginx documentation.
 ### Database authentication in Klaw
 
 In Klaw, you can configure database-level authentication by setting
-`klaw.login.authentication.type: db` in the core mode
+`klaw.login.authentication.type: db` in the Klaw Core mode
 application properties.
 
 With database authentication, Klaw uses the Spring JSESSION ID. When
@@ -295,7 +295,7 @@ upstream klawgcp {
 Using IP-Hash method, sessions are maintained by tracking the client's
 IP address. Single Sign-On (SSO) authentication in Klaw For SSO
 authentication, configure Klaw by setting
-`klaw.login.authentication.type: ad` in the core mode
+`klaw.login.authentication.type: ad` in the Klaw Core mode
 application properties. When SSO is enabled, either Round-Robin or
 Least-Connected load balancing methods can be used.
 

--- a/docs/Concepts/high-availability.md
+++ b/docs/Concepts/high-availability.md
@@ -31,7 +31,7 @@ software architecture that surpasses hardware limitations.
 
 ## How to configure and enable High Availability
 
-In the Klaw core module, configure the below property, which is a
+In the Klaw Core module, configure the below property, which is a
 comma-separated list of Klaw instances.
 
     klaw.uiapi.servers=https://klawhost1:9097,https://klawhost2:9097

--- a/docs/HowTo/authentication/azure-ad.md
+++ b/docs/HowTo/authentication/azure-ad.md
@@ -8,7 +8,7 @@ credentials or select an Azure account.
 
 Before using Azure AD to log in with Klaw, you need to make the
 following configurations in the `application.properties` file in
-Klaw-core module to enable Azure AD.
+Klaw Core module to enable Azure AD.
 
 1.  Make sure Klaw is running in a secure mode. You will find the
     following configuration: `server.ssl.key-store.`

--- a/docs/HowTo/authentication/google-account.md
+++ b/docs/HowTo/authentication/google-account.md
@@ -7,7 +7,7 @@ enter your credentials or select an Azure account.
 
 Before using Google account credentials to log in to Klaw, you need to
 make the following configurations in the `application.properties` file
-in the Klaw-core module to enable the use of Google account login.
+in the Klaw Core module to enable the use of Google account login.
 
 1.  Make sure Klaw is running in a secure mode. You will find the
     following configuration:

--- a/docs/HowTo/authentication/third-party-account.md
+++ b/docs/HowTo/authentication/third-party-account.md
@@ -4,7 +4,7 @@ You have the option to configure any third-party login account to access
 Klaw.
 
 To enable third-party login accounts, you need to make the following
-configurations in the `application.properties` file in the Klaw-core
+configurations in the `application.properties` file in the Klaw Core
 module.
 
 1. Make sure Klaw is running in a secure mode. You will find the following configuration:

--- a/docs/HowTo/authentication/windows-ad.md
+++ b/docs/HowTo/authentication/windows-ad.md
@@ -3,7 +3,7 @@
 You can log in to Klaw using the Windows credentials configured in the Windows active directory.
 
 Before you can proceed with using your Windows Active directory credentials, you need to make the following
-configurations in the `application.properties` file in the Klaw-core module.
+configurations in the `application.properties` file in the Klaw Core module.
 
 1. Configure the authentication type by setting the value to `ad` in the following property:
 

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-sasl-ssl-protocol.md
@@ -5,8 +5,7 @@ Apache Kafka® cluster with Klaw using the SASL_SSL authentication protocol.
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Cluster
-  API), see `klaw-core-with-clusterapi`.
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster API), see `klaw-core-with-clusterapi`.
   This involves configuring the `klaw.clusterapi.url` setting in the
   Klaw UI and testing the connectivity to ensure the two APIs can
   communicate.

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-cluster-ssl-protocol.md
@@ -6,7 +6,7 @@ cluster with Klaw using SSL authentication protocol.
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Klaw Cluster
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster
   API), see `klaw-core-with-clusterapi`.
   This involves configuring the `klaw.clusterapi.url` setting in the
   Klaw UI and testing the connectivity to ensure the two APIs can

--- a/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-kafka-connect-cluster-ssl-protocol.md
@@ -10,7 +10,7 @@ Apache Kafka Connect service with Klaw using SSL protocol.
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Klaw Cluster
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster
   API) to use secure SSL, see
   `klaw-core-with-clusterapi`. This
   involves configuring the `klaw.clusterapi.url` setting in the Klaw

--- a/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/aiven-karapace-cluster-ssl-protocol.md
@@ -5,7 +5,7 @@ Schema Registry over the REST protocol.
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Klaw Cluster
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster
   API) to use secure SSL, see
   `klaw-core-with-clusterapi`. This
   involves configuring the `klaw.clusterapi.url` setting in the Klaw

--- a/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/confluent-cloud-kafka-cluster-ssl-protocol.md
@@ -23,7 +23,7 @@ References:
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Klaw Cluster
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster
   API), see `klaw-core-with-clusterapi`.
   This involves configuring the `klaw.clusterapi.url` setting in the
   Klaw UI and testing the connectivity to ensure the two APIs can

--- a/docs/HowTo/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/kafka-cluster-sasl-ssl-protocol.md
@@ -4,7 +4,7 @@ This section provides information on connecting Klaw to an Apache Kafka cluster 
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Klaw Cluster
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster
   API), see `klaw-core-with-clusterapi`.
   This involves configuring the `klaw.clusterapi.url` setting in the
   Klaw UI and testing the connectivity to ensure the two APIs can

--- a/docs/HowTo/clusterconnectivity/kafka-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/kafka-cluster-ssl-protocol.md
@@ -9,7 +9,7 @@ Kafka cluster to Klaw using SSL protocol.
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Klaw Cluster
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster
   API), see `klaw-core-with-clusterapi`.
   This involves configuring the `klaw.clusterapi.url` setting in the
   Klaw UI and testing the connectivity to ensure the two APIs can

--- a/docs/HowTo/clusterconnectivity/klaw-core-with-clusterapi.md
+++ b/docs/HowTo/clusterconnectivity/klaw-core-with-clusterapi.md
@@ -1,13 +1,13 @@
 # Connect Klaw Core and Klaw Cluster APIs
 
 To run Klaw successfully and perform all the necessary operations on a Kafka cluster, you must connect the Klaw APIs (
-Core API and Klaw Cluster API). This involves configuring the secret key and SSL protocols in the
+Klaw Core API and Klaw Cluster API). This involves configuring the secret key and SSL protocols in the
 respective `application.properties` files and verifying the connectivity between the APIs.
 
 You can find the `application.properties` file located in the following paths:
 
-- Core: [klaw/core/src/main/resources]
-- Cluster-API: `klaw/cluster-api/src/main/resources`
+- Klaw Core: [klaw/core/src/main/resources]
+- Klaw Cluster API: `klaw/cluster-api/src/main/resources`
 
 ## Configure Klaw application.properties file
 

--- a/docs/HowTo/clusterconnectivity/klaw-db-connection.md
+++ b/docs/HowTo/clusterconnectivity/klaw-db-connection.md
@@ -8,7 +8,7 @@ RDBMS, such as MySQL, Oracle, or PostgreSQL®.
 
 The configuration for the default file-based database in Klaw is
 specified in the `application.properties` file in the core
-(klaw/core/src/main/resources) module. For example, your configuration
+(`klaw/core/src/main/resources`) module. For example, your configuration
 might look something similar to this:
 
 ```java
@@ -30,7 +30,7 @@ MySQL, Oracle, or PostgreSQL.
 To configure a connection to a relational database management system
 (RDBMS) such as Postgres, Oracle, or MySQL, you need to edit the
 `application.properties` file location in the
-core(klaw/core/src/main/resources) module, with the connection details
+core(`klaw/core/src/main/resources`) module, with the connection details
 for your database.
 
 Below is a sample configuration for MySQL:

--- a/docs/HowTo/clusterconnectivity/sr-cluster-ssl-protocol.md
+++ b/docs/HowTo/clusterconnectivity/sr-cluster-ssl-protocol.md
@@ -5,7 +5,7 @@ Schema Registry over the REST protocol.
 
 ## Prerequisite
 
-- Set up the connection between the Klaw APIs (Core API and Klaw Cluster
+- Set up the connection between the Klaw APIs (Klaw Core API and Klaw Cluster
   API) to use secure SSL, see
   `klaw-core-with-clusterapi`. This
   involves configuring the `klaw.clusterapi.url` setting in the Klaw
@@ -38,7 +38,7 @@ cluster with Klaw using SSL protocol:
 6.  In the **Schema Registry Environments** section, click **Add
     Environment** and enter the details to add your schema registry
     environment. Click **Save**.
-7.  Open the `application.properties` file for [core](https://github.com/aiven/klaw/tree/main/core)
+7.  Open the `application.properties` file for [`core`](https://github.com/aiven/klaw/tree/main/core)
     and [`cluster-api`](https://github.com/aiven/klaw/tree/main/cluster-api) modules.
 
 8.  Copy the **Cluster ID** from the **Clusters** page using the copy

--- a/docs/HowTo/installation/run-docker.md
+++ b/docs/HowTo/installation/run-docker.md
@@ -3,7 +3,7 @@
 Klaw provides Docker images that allow you to run Klaw inside Docker
 containers. There are two Docker images available:
 
-- Core API: `https://hub.docker.com/r/aivenoy/klaw-core`
+- Klaw Core API: `https://hub.docker.com/r/aivenoy/klaw-core`
 - Klaw Cluster API: `https://hub.docker.com/r/aivenoy/klaw-cluster-api`
 
 ## Prerequisites
@@ -254,7 +254,7 @@ There are two ways to configure this:
   version copied over to the volume as this is usually updated during the
   build to keep the API versions in line with the pom version. \* Also,
   ensure that the `application.properties` is renamed to a unique
-  properties file name, so you don't accidentally copy over the Core
+  properties file name, so you don't accidentally copy over the Klaw Core
   properties with the cluster properties and vice versa.
 
       environment:

--- a/docs/HowTo/installation/run-source.md
+++ b/docs/HowTo/installation/run-source.md
@@ -26,7 +26,7 @@ the source.
 3. Configure Klaw Cluster API access
 
    - Configure the property `klaw.clusterapi.access.base64.secret` in the `application.properties` file with a base64
-     string in the module: core.
+     string in the module: `core`.
    - Configure the property `klaw.clusterapi.access.base64.secret` in the `application.properties` file with the above
      base64 string in the module: `cluster-api`.
 
@@ -41,14 +41,14 @@ the source.
    ```
 
 4. Build the project by running `./mvnw clean package` for Linux(bash) or `mvnw clean package` for Windows, from the top
-   level of the project directory. This will build JAR files in the `target/` directories of each module: core and
+   level of the project directory. This will build JAR files in the `target/` directories of each module: `core` and
    `cluster-api`.
 
    node, npm, and pnpm are also installed locally (required for React UI assets) through maven execution plugins.
 
    If the build runs into an error while installing node/npm/pnpm, you can
 
-   - Disable the execution plugins (for node/npm/pnpm) in module core/pom.xml
+   - Disable the execution plugins (for node/npm/pnpm) in module `core/pom.xml`
    - Manually install node/npm/pnpm and copy assets by following the procedure
      here. [Manual installation of React](https://github.com/aiven/klaw/blob/main/coral/README.md)
 
@@ -56,8 +56,8 @@ the source.
 
    - Run with script
 
-     In the bin directory of the repository, run the script `run-klaw.sh` for Mac or Linux, which starts both Core and
-     Cluster-API applications.
+     In the bin directory of the repository, run the script `run-klaw.sh` for Mac or Linux, which starts both Klaw Core and
+     Klaw Cluster API applications.
 
    Alternatively
 

--- a/docs/HowTo/notifications/email-notification.md
+++ b/docs/HowTo/notifications/email-notification.md
@@ -8,7 +8,7 @@ Skip to see all notifications sent and to which users [Email Matrix](#email-matr
 ## Configure email notifications
 
 You can configure email notifications in the `application.properties`
-file of Klaw-core. Refer to the documentation provided by your email
+file of Klaw Core. Refer to the documentation provided by your email
 service provider for instructions on how to configure email
 notifications. Additionally, make sure you have the `host`, `username`,
 and `password` details as you will need to provide this information to

--- a/docs/HowTo/settings.md
+++ b/docs/HowTo/settings.md
@@ -43,10 +43,10 @@ notification templates and roles, under **Dashboard -\> Settings**.
   false.
 - **Klaw Cluster API connectivity**  
   When installing Klaw, it is important
-  to establish the connectivity between Core API and Klaw Cluster API. You
+  to establish the connectivity between Klaw Core API and Klaw Cluster API. You
   can test this connectivity by updating the property
   `klaw.clusterapi.url`.
-- **Stop Core API**  
-  You can stop the Core API by clicking the Stop
+- **Stop Klaw Core API**  
+  You can stop the Klaw Core API by clicking the Stop
   button. However, it will be your responsibility as an Administrator
   to start it again if required.

--- a/docs/Releases/release200.md
+++ b/docs/Releases/release200.md
@@ -35,7 +35,7 @@ following user interfaces:
 ![image](../../static/images/topic/RequestTopic-react.png)
 
 To preview the new Klaw user interface, open the
-`application.properties` file on the Klaw **core** module, and set the
+`application.properties` file on the Klaw **`core`** module, and set the
 value of the following property to `true`:
 
     # Enable new Klaw user

--- a/docs/Releases/release250.md
+++ b/docs/Releases/release250.md
@@ -26,8 +26,8 @@ schemas from schema registry to Klaw, and vice versa.
 
 ### Docker
 
-[Klaw-core](https://hub.docker.com/r/aivenoy/klaw-core)
-[Klaw-cluster-API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+[Klaw Core](https://hub.docker.com/r/aivenoy/klaw-core)
+[Klaw Cluster API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
 
 ## What's new in Klaw 2.5.0
 

--- a/docs/Releases/release251.md
+++ b/docs/Releases/release251.md
@@ -24,8 +24,8 @@ Klaw version 2.5.1 is a patch release primarily aimed at enhancing MySQL support
 
 ### Docker
 
-- [Klaw-core](https://hub.docker.com/r/aivenoy/klaw-core)
-- [Klaw-cluster-API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+- [Klaw Core](https://hub.docker.com/r/aivenoy/klaw-core)
+- [Klaw Cluster API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
 
 ## What's new in Klaw 2.5.1
 

--- a/docs/Releases/release260.md
+++ b/docs/Releases/release260.md
@@ -26,8 +26,8 @@ schemas from schema registry to Klaw, and vice versa.
 
 ### Docker
 
-[Klaw-core](https://hub.docker.com/r/aivenoy/klaw-core)
-[Klaw-cluster-API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+[Klaw Core](https://hub.docker.com/r/aivenoy/klaw-core)
+[Klaw Cluster API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
 
 ## What's new in Klaw 2.6.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ sidebar_position: 1.0
 
 Klaw consists of two components:
 
-- The main Klaw core application handling Governance, Security and meta storage.
+- The main Klaw Core application handling Governance, Security and meta storage.
 - The Klaw Cluster API handling the connections to the Apache Kafka,
   Apache Kafka Connect and Schema Registry servers.
 


### PR DESCRIPTION
# Description

This PR:

- adds the rule for correct usage of "Klaw Core" as error
- extends existing rule for "Klaw Cluster API"
- updates usage of wrong spelling in markdown

Resolves #103 