### PR TITLE
Add release notes for release 2.8.1

### DIFF
--- a/docs/releases/release280.md
+++ b/docs/releases/release280.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 99.88
+sidebar_position: 99.89
 ---
 
 # Release 2.8.0
@@ -16,18 +16,18 @@ kafka clients on schema changes
 
 ### Binaries
 
-[`klaw-2.8.0.jar` ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.8.0/klaw-2.8.0.jar)
+[`klaw-2.8.0.jar` ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v.2.8.0/klaw-2.8.0.jar)
 
-[`cluster-api-2.8.0.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.8.0/cluster-api-2.8.0.jar)
+[`cluster-api-2.8.0.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v.2.8.0/cluster-api-2.8.0.jar)
 
 ### Sources
 
-[`klaw-2.8.0.zip` ⬇](https://github.com/Aiven-Open/klaw/archive/refs/tags/v2.8.0.zip)
+[`klaw-2.8.0.zip` ⬇](https://github.com/Aiven-Open/klaw/archive/refs/tags/v.2.8.0.zip)
 
 ### Docker
 
-- [Klaw Core](https://hub.docker.com/r/aivenoy/klaw-core)
-- [Klaw Cluster API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+[Klaw Core](https://hub.docker.com/r/aivenoy/klaw-core)
+[Klaw Cluster API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
 
 ## What's new in Klaw 2.8.0
 
@@ -37,26 +37,19 @@ In this release, we have redesigned the user interface using React to enhance th
 
 Key updates in the new React UI include:
 
-- Topic catalog - Filter by Topic type
-  ![image](../../static/images/release280/Filter-by.png)
-- Activity log
-  ![image](../../static/images/release280/Activity-Log.png)
+- Topic Catalogue - Filter by Topic Type
+- Activity Log
 - Dashboard landing page
-  ![image](../../static/images/release280/Dashboard.png)
-- View clusters
-  ![image](../../static/images/release280/view-clusters.png)
-- View environments
-  ![image](../../static/images/release280/view-envs.png)
+- View Clusters
+- View Environments
 
 To disable the preview for the new Klaw user interface, open the
 `application.properties` file on the Klaw **core** module, and set the
 value of the following property to `false` (Effective from version 2.4.0, it
 is true by default):
 
-```properties
     #Enable new Klaw user interface
     klaw.coral.enabled=false
-```
 
 :::note
 We are taking an incremental, feedback-driven approach in rolling out
@@ -65,29 +58,29 @@ interfaces, we would like you to share your valuable
 [feedback](https://github.com/aiven/klaw/issues/new?assignees=&labels=&template=03_feature.md).
 :::
 
-### Feedback form to help gather community feedback for Klaw
+### Feedback Form to help gather community feedback for Klaw
 
-Available in the angular view, a new feedback form is now available to have your thoughts and feedback better included in the planning and future trajectory of Klaw
+Available in the angular view a new submit feedback form is now available to have your thoughts and feedback better included in Klaws planning and future trajectory
 
 ### New Klaw documentation site structure implemented
 
-The documentation website has an updated navigation to improve usability.
+The klaw-project.io documentation website has an updated navigation to improve useability.
 
 ### Improvements
 
-- A new optional permission to only allow certain users to create the initial topic
+- A new optional permission to only allow certain users create the initial topic
 - Allow Deletion of a Superadmin User
-- Redesigned Login, Forgot Password, and Sign Up Pages
+- Redesigned Login, Forgot Password and Sign Up Pages
 
-### Bug fixes
+### Bug Fixes
 
-- Fix analytics for the dashboard and added 30/60/90 day drop down in coral
+- Fix analytics for the dashboard and add 30/60/90 day drop down in coral
 - New User email only sent to the user directly now
 - Version number for data migration is now stored internally instead of through the application.properties
 
 ### DB upgrade
 
-In this release, there is a migration utility to add a new fine-grain permission.
+In this release there is a migration utility to add a new fine grain permission.
 
 :::note
 For a complete list of improvements, changelog, and to download the

--- a/docs/releases/release280.md
+++ b/docs/releases/release280.md
@@ -16,18 +16,18 @@ kafka clients on schema changes
 
 ### Binaries
 
-[`klaw-2.8.0.jar` ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v.2.8.0/klaw-2.8.0.jar)
+[`klaw-2.8.0.jar` ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.8.0/klaw-2.8.0.jar)
 
-[`cluster-api-2.8.0.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v.2.8.0/cluster-api-2.8.0.jar)
+[`cluster-api-2.8.0.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.8.0/cluster-api-2.8.0.jar)
 
 ### Sources
 
-[`klaw-2.8.0.zip` ⬇](https://github.com/Aiven-Open/klaw/archive/refs/tags/v.2.8.0.zip)
+[`klaw-2.8.0.zip` ⬇](https://github.com/Aiven-Open/klaw/archive/refs/tags/v2.8.0.zip)
 
 ### Docker
 
-[Klaw Core](https://hub.docker.com/r/aivenoy/klaw-core)
-[Klaw Cluster API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+- [Klaw Core](https://hub.docker.com/r/aivenoy/klaw-core)
+- [Klaw Cluster API](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
 
 ## What's new in Klaw 2.8.0
 
@@ -37,19 +37,26 @@ In this release, we have redesigned the user interface using React to enhance th
 
 Key updates in the new React UI include:
 
-- Topic Catalogue - Filter by Topic Type
-- Activity Log
+- Topic catalog - Filter by Topic type
+  ![image](../../static/images/release280/Filter-by.png)
+- Activity log
+  ![image](../../static/images/release280/Activity-Log.png)
 - Dashboard landing page
-- View Clusters
-- View Environments
+  ![image](../../static/images/release280/Dashboard.png)
+- View clusters
+  ![image](../../static/images/release280/view-clusters.png)
+- View environments
+  ![image](../../static/images/release280/view-envs.png)
 
 To disable the preview for the new Klaw user interface, open the
 `application.properties` file on the Klaw **core** module, and set the
 value of the following property to `false` (Effective from version 2.4.0, it
 is true by default):
 
+```properties
     #Enable new Klaw user interface
     klaw.coral.enabled=false
+```
 
 :::note
 We are taking an incremental, feedback-driven approach in rolling out
@@ -58,29 +65,29 @@ interfaces, we would like you to share your valuable
 [feedback](https://github.com/aiven/klaw/issues/new?assignees=&labels=&template=03_feature.md).
 :::
 
-### Feedback Form to help gather community feedback for Klaw
+### Feedback form to help gather community feedback for Klaw
 
-Available in the angular view a new submit feedback form is now available to have your thoughts and feedback better included in Klaws planning and future trajectory
+Available in the angular view, a new feedback form is now available to have your thoughts and feedback better included in the planning and future trajectory of Klaw
 
 ### New Klaw documentation site structure implemented
 
-The klaw-project.io documentation website has an updated navigation to improve useability.
+The documentation website has an updated navigation to improve usability.
 
 ### Improvements
 
-- A new optional permission to only allow certain users create the initial topic
+- A new optional permission to only allow certain users to create the initial topic
 - Allow Deletion of a Superadmin User
-- Redesigned Login, Forgot Password and Sign Up Pages
+- Redesigned Login, Forgot Password, and Sign Up Pages
 
-### Bug Fixes
+### Bug fixes
 
-- Fix analytics for the dashboard and add 30/60/90 day drop down in coral
+- Fix analytics for the dashboard and added 30/60/90 day drop down in coral
 - New User email only sent to the user directly now
 - Version number for data migration is now stored internally instead of through the application.properties
 
 ### DB upgrade
 
-In this release there is a migration utility to add a new fine grain permission.
+In this release, there is a migration utility to add a new fine-grain permission.
 
 :::note
 For a complete list of improvements, changelog, and to download the

--- a/docs/releases/release280.md
+++ b/docs/releases/release280.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 99.89
+sidebar_position: 99.88
 ---
 
 # Release 2.8.0

--- a/docs/releases/release281.md
+++ b/docs/releases/release281.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 99.90
+---
+
+# Release 2.8.1
+
+Date: 21st of March, 2024
+
+## Overview
+
+Overview
+Klaw version 2.8.1 is a patch release which fixes an issue introduced in 2.8.0 related to creating new users where the username uses an email id pattern.
+Release 2.8.1 accepts regular alphanumeric and email ids as usernames as per previous releases.
+
+## Download
+
+### Binaries
+
+[`klaw-2.8.1.jar` ⬇︎](https://github.com/Aiven-Open/klaw/releases/download/v2.8.1/klaw-2.8.1.jar)
+
+[`cluster-api-2.8.1.jar` ⬇](https://github.com/Aiven-Open/klaw/releases/download/v2.8.1/cluster-api-2.8.1.jar)
+
+### Sources
+
+[`klaw-2.8.1.zip` ⬇](https://github.com/Aiven-Open/klaw/archive/refs/tags/v2.8.1.zip)
+
+### Docker
+
+[`Klaw-core`](https://hub.docker.com/r/aivenoy/klaw-core)
+[`Klaw-cluster-API`](https://hub.docker.com/r/aivenoy/klaw-cluster-api)
+
+:::note
+For a complete list of improvements, changelog, and to download the
+release, see [GitHub release tag v2.8.1](https://github.com/aiven/klaw/releases/tag/v2.8.1)

--- a/docs/releases/release281.md
+++ b/docs/releases/release281.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 99.90
+sidebar_position: 99.87
 ---
 
 # Release 2.8.1


### PR DESCRIPTION
Quick release notes for a patch release of Klaw 2.8.1 to fix a small bug introduced in 2.8.0 which removed the ability to user email ids as usernames for new users.